### PR TITLE
Remove reexports

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+max_width = 80
+wrap_comments = true
+reorder_imports = true
+edition = "2021"

--- a/examples/dump_ipv4.rs
+++ b/examples/dump_ipv4.rs
@@ -1,9 +1,12 @@
 // SPDX-License-Identifier: MIT
 
+use netlink_packet_core::{
+    NetlinkHeader, NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST,
+};
 use netlink_packet_sock_diag::{
     constants::*,
     inet::{ExtensionFlags, InetRequest, SocketId, StateFlags},
-    NetlinkHeader, NetlinkMessage, NetlinkPayload, SockDiagMessage,
+    SockDiagMessage,
 };
 use netlink_sys::{protocols::NETLINK_SOCK_DIAG, Socket, SocketAddr};
 

--- a/examples/dump_ipv4.rs
+++ b/examples/dump_ipv4.rs
@@ -33,15 +33,16 @@ fn main() {
 
     let mut buf = vec![0; packet.header.length as usize];
 
-    // Before calling serialize, it is important to check that the buffer in which
-    // we're emitting is big enough for the packet, other `serialize()` panics.
+    // Before calling serialize, it is important to check that the buffer in
+    // which we're emitting is big enough for the packet, other
+    // `serialize()` panics.
     assert_eq!(buf.len(), packet.buffer_len());
 
     packet.serialize(&mut buf[..]);
 
-    println!(">>> {:?}", packet);
+    println!(">>> {packet:?}");
     if let Err(e) = socket.send(&buf[..], 0) {
-        println!("SEND ERROR {}", e);
+        println!("SEND ERROR {e}");
         return;
     }
 
@@ -50,13 +51,16 @@ fn main() {
     while let Ok(size) = socket.recv(&mut &mut receive_buffer[..], 0) {
         loop {
             let bytes = &receive_buffer[offset..];
-            let rx_packet = <NetlinkMessage<SockDiagMessage>>::deserialize(bytes).unwrap();
-            println!("<<< {:?}", rx_packet);
+            let rx_packet =
+                <NetlinkMessage<SockDiagMessage>>::deserialize(bytes).unwrap();
+            println!("<<< {rx_packet:?}");
 
             match rx_packet.payload {
                 NetlinkPayload::Noop | NetlinkPayload::Ack(_) => {}
-                NetlinkPayload::InnerMessage(SockDiagMessage::InetResponse(response)) => {
-                    println!("{:#?}", response);
+                NetlinkPayload::InnerMessage(
+                    SockDiagMessage::InetResponse(response),
+                ) => {
+                    println!("{response:#?}");
                 }
                 NetlinkPayload::Done => {
                     println!("Done!");

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 
-use crate::{
-    constants::*,
-    inet,
-    traits::{Parseable, ParseableParametrized},
-    unix, DecodeError, SockDiagMessage,
-};
 use anyhow::Context;
+use netlink_packet_utils::{
+    traits::{Parseable, ParseableParametrized},
+    DecodeError,
+};
+
+use crate::{constants::*, inet, unix, SockDiagMessage};
 
 const BUF_MIN_LEN: usize = 2;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MIT
 
-pub use netlink_packet_core::constants::*;
-
 pub const SOCK_DIAG_BY_FAMILY: u16 = 20;
 pub const SOCK_DESTROY: u16 = 21;
 

--- a/src/inet/nlas.rs
+++ b/src/inet/nlas.rs
@@ -3,14 +3,15 @@
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 
-pub use crate::utils::nla::{DefaultNla, NlaBuffer, NlasIterator};
-
-use crate::{
-    constants::*,
+use netlink_packet_utils::{
+    buffer,
+    nla::{self, DefaultNla, NlaBuffer},
     parsers::{parse_string, parse_u32, parse_u8},
     traits::{Emitable, Parseable},
     DecodeError,
 };
+
+use crate::constants::*;
 
 pub const LEGACY_MEM_INFO_LEN: usize = 16;
 
@@ -251,7 +252,7 @@ pub enum Nla {
     Other(DefaultNla),
 }
 
-impl crate::utils::nla::Nla for Nla {
+impl nla::Nla for Nla {
     fn value_len(&self) -> usize {
         use self::Nla::*;
         match *self {

--- a/src/inet/request.rs
+++ b/src/inet/request.rs
@@ -97,18 +97,20 @@ bitflags! {
     /// This is a set of flags defining what kind of extended
     /// information to report.
     pub struct ExtensionFlags: u8 {
-        const MEMINFO = 1 << (INET_DIAG_MEMINFO as u16 - 1);
-        const INFO = 1 << (INET_DIAG_INFO as u16 - 1);
-        const VEGASINFO = 1 << (INET_DIAG_VEGASINFO as u16 - 1);
-        const CONG = 1 << (INET_DIAG_CONG as u16 - 1);
-        const TOS = 1 << (INET_DIAG_TOS as u16 - 1);
-        const TCLASS = 1 << (INET_DIAG_TCLASS as u16 - 1);
-        const SKMEMINFO = 1 << (INET_DIAG_SKMEMINFO as u16 - 1);
-        const SHUTDOWN = 1 << (INET_DIAG_SHUTDOWN as u16 - 1);
+        const MEMINFO = 1 << (INET_DIAG_MEMINFO - 1);
+        const INFO = 1 << (INET_DIAG_INFO - 1);
+        const VEGASINFO = 1 << (INET_DIAG_VEGASINFO - 1);
+        const CONG = 1 << (INET_DIAG_CONG - 1);
+        const TOS = 1 << (INET_DIAG_TOS - 1);
+        const TCLASS = 1 << (INET_DIAG_TCLASS - 1);
+        const SKMEMINFO = 1 << (INET_DIAG_SKMEMINFO - 1);
+        const SHUTDOWN = 1 << (INET_DIAG_SHUTDOWN - 1);
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetRequestBuffer<&'a T>> for InetRequest {
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<InetRequestBuffer<&'a T>>
+    for InetRequest
+{
     fn parse(buf: &InetRequestBuffer<&'a T>) -> Result<Self, DecodeError> {
         let err = "invalid socket_id value";
         let socket_id = SocketId::parse_with_param(

--- a/src/inet/request.rs
+++ b/src/inet/request.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 
 use anyhow::Context;
+use netlink_packet_utils::{
+    buffer,
+    traits::{Emitable, Parseable, ParseableParametrized},
+    DecodeError,
+};
 
 use crate::{
     constants::*,
     inet::{SocketId, SocketIdBuffer},
-    traits::{Emitable, Parseable, ParseableParametrized},
-    DecodeError,
 };
 
 pub const REQUEST_LEN: usize = 56;

--- a/src/inet/response.rs
+++ b/src/inet/response.rs
@@ -74,7 +74,9 @@ pub struct InetResponseHeader {
     pub inode: u32,
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>> for InetResponseHeader {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>>
+    for InetResponseHeader
+{
     fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         let err = "invalid socket_id value";
         let socket_id = SocketId::parse_with_param(
@@ -165,12 +167,16 @@ pub struct InetResponse {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> InetResponseBuffer<&'a T> {
-    pub fn nlas(&self) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    pub fn nlas(
+        &self,
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
         NlasIterator::new(self.payload())
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>> for SmallVec<[Nla; 8]> {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>>
+    for SmallVec<[Nla; 8]>
+{
     fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = smallvec![];
         for nla_buf in buf.nlas() {
@@ -180,12 +186,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>> for Small
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>> for InetResponse {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<InetResponseBuffer<&'a T>>
+    for InetResponse
+{
     fn parse(buf: &InetResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let header =
-            InetResponseHeader::parse(buf).context("failed to parse inet response header")?;
-        let nlas =
-            SmallVec::<[Nla; 8]>::parse(buf).context("failed to parse inet response NLAs")?;
+        let header = InetResponseHeader::parse(buf)
+            .context("failed to parse inet response header")?;
+        let nlas = SmallVec::<[Nla; 8]>::parse(buf)
+            .context("failed to parse inet response NLAs")?;
         Ok(InetResponse { header, nlas })
     }
 }

--- a/src/inet/response.rs
+++ b/src/inet/response.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use smallvec::SmallVec;
 use std::time::Duration;
 
-use crate::{
-    inet::{
-        nlas::{Nla, NlaBuffer, NlasIterator},
-        SocketId, SocketIdBuffer,
-    },
+use anyhow::Context;
+use netlink_packet_utils::{
+    buffer,
+    nla::{NlaBuffer, NlasIterator},
     traits::{Emitable, Parseable, ParseableParametrized},
     DecodeError,
 };
+use smallvec::SmallVec;
+
+use crate::inet::{nlas::Nla, SocketId, SocketIdBuffer};
 
 /// The type of timer that is currently active for a TCP socket.
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/inet/socket_id.rs
+++ b/src/inet/socket_id.rs
@@ -1,16 +1,18 @@
 // SPDX-License-Identifier: MIT
 
-use byteorder::{BigEndian, ByteOrder};
 use std::{
     convert::{TryFrom, TryInto},
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use crate::{
-    constants::*,
+use byteorder::{BigEndian, ByteOrder};
+use netlink_packet_utils::{
+    buffer,
     traits::{Emitable, ParseableParametrized},
     DecodeError,
 };
+
+use crate::constants::*;
 
 pub const SOCKET_ID_LEN: usize = 48;
 

--- a/src/inet/tests.rs
+++ b/src/inet/tests.rs
@@ -5,13 +5,14 @@ use std::{
     time::Duration,
 };
 
+use netlink_packet_utils::traits::{Emitable, Parseable};
+
 use crate::{
     constants::*,
     inet::{
         nlas::Nla, ExtensionFlags, InetRequest, InetRequestBuffer, InetResponse,
         InetResponseBuffer, InetResponseHeader, SocketId, StateFlags, Timer,
     },
-    traits::{Emitable, Parseable},
 };
 
 lazy_static! {

--- a/src/inet/tests.rs
+++ b/src/inet/tests.rs
@@ -10,14 +10,15 @@ use netlink_packet_utils::traits::{Emitable, Parseable};
 use crate::{
     constants::*,
     inet::{
-        nlas::Nla, ExtensionFlags, InetRequest, InetRequestBuffer, InetResponse,
-        InetResponseBuffer, InetResponseHeader, SocketId, StateFlags, Timer,
+        nlas::Nla, ExtensionFlags, InetRequest, InetRequestBuffer,
+        InetResponse, InetResponseBuffer, InetResponseHeader, SocketId,
+        StateFlags, Timer,
     },
 };
 
 lazy_static! {
     static ref REQ_UDP: InetRequest = InetRequest {
-        family: AF_INET as u8,
+        family: AF_INET,
         protocol: IPPROTO_UDP,
         extensions: ExtensionFlags::empty(),
         states: StateFlags::ESTABLISHED,
@@ -48,8 +49,10 @@ static REQ_UDP_BUF: [u8; 56] = [
 
 #[test]
 fn parse_udp_req() {
-    let parsed =
-        InetRequest::parse(&InetRequestBuffer::new_checked(&&REQ_UDP_BUF[..]).unwrap()).unwrap();
+    let parsed = InetRequest::parse(
+        &InetRequestBuffer::new_checked(&&REQ_UDP_BUF[..]).unwrap(),
+    )
+    .unwrap();
     assert_eq!(parsed, *REQ_UDP);
 }
 
@@ -64,7 +67,7 @@ fn emit_udp_req() {
 lazy_static! {
     static ref RESP_TCP: InetResponse = InetResponse {
         header: InetResponseHeader {
-            family: AF_INET as u8,
+            family: AF_INET,
             state: TCP_ESTABLISHED,
             timer: Some(Timer::KeepAlive(Duration::from_millis(0x0000_6080))),
             recv_queue: 0,
@@ -75,7 +78,9 @@ lazy_static! {
                 source_port: 60180,
                 destination_port: 443,
                 source_address: IpAddr::V4(Ipv4Addr::new(192, 168, 178, 60)),
-                destination_address: IpAddr::V4(Ipv4Addr::new(172, 217, 23, 131)),
+                destination_address: IpAddr::V4(Ipv4Addr::new(
+                    172, 217, 23, 131
+                )),
                 interface_id: 0,
                 cookie: [0x52, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
             },
@@ -118,8 +123,10 @@ static RESP_TCP_BUF: [u8; 80] = [
 
 #[test]
 fn parse_tcp_resp() {
-    let parsed =
-        InetResponse::parse(&InetResponseBuffer::new_checked(&&RESP_TCP_BUF[..]).unwrap()).unwrap();
+    let parsed = InetResponse::parse(
+        &InetResponseBuffer::new_checked(&&RESP_TCP_BUF[..]).unwrap(),
+    )
+    .unwrap();
     assert_eq!(parsed, *RESP_TCP);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,15 +3,6 @@
 #[macro_use]
 extern crate bitflags;
 
-#[macro_use]
-pub(crate) extern crate netlink_packet_utils as utils;
-pub(crate) use self::utils::parsers;
-pub use self::utils::{traits, DecodeError};
-pub use netlink_packet_core::{
-    ErrorMessage, NetlinkBuffer, NetlinkHeader, NetlinkMessage, NetlinkPayload,
-};
-pub(crate) use netlink_packet_core::{NetlinkDeserializable, NetlinkSerializable};
-
 #[cfg(test)]
 #[macro_use]
 extern crate lazy_static;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MIT
 
-use crate::{
-    inet,
-    traits::{Emitable, ParseableParametrized},
-    unix, DecodeError, NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
-    SockDiagBuffer, SOCK_DIAG_BY_FAMILY,
+use netlink_packet_core::{
+    NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
 };
+use netlink_packet_utils::{
+    traits::{Emitable, ParseableParametrized},
+    DecodeError,
+};
+
+use crate::{inet, unix, SockDiagBuffer, SOCK_DIAG_BY_FAMILY};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SockDiagMessage {

--- a/src/message.rs
+++ b/src/message.rs
@@ -79,7 +79,10 @@ impl NetlinkSerializable for SockDiagMessage {
 
 impl NetlinkDeserializable for SockDiagMessage {
     type Error = DecodeError;
-    fn deserialize(header: &NetlinkHeader, payload: &[u8]) -> Result<Self, Self::Error> {
+    fn deserialize(
+        header: &NetlinkHeader,
+        payload: &[u8],
+    ) -> Result<Self, Self::Error> {
         let buffer = SockDiagBuffer::new_checked(&payload)?;
         SockDiagMessage::parse_with_param(&buffer, header.message_type)
     }

--- a/src/unix/nlas.rs
+++ b/src/unix/nlas.rs
@@ -41,16 +41,16 @@ pub enum Nla {
     ///
     /// - the first the number is the number of pending connections. It should
     ///   be equal to `Nla::PendingConnections` value's length.
-    /// - the second number is the backlog queue maximum length, which equals to
-    ///   the value passed as the second argument to `listen(2)`
+    /// - the second number is the backlog queue maximum length, which equals
+    ///   to the value passed as the second argument to `listen(2)`
     ///
     /// For other sockets:
     ///
     /// - the first number is the amount of data in receive queue (**note**: I
-    ///   am not sure if it is the actual amount of data or the amount of memory
-    ///   allocated. The two might differ because of memory allocation
-    ///   strategies: more memory than strictly necessary may be allocated for a
-    ///   given `sk_buff`)
+    ///   am not sure if it is the actual amount of data or the amount of
+    ///   memory allocated. The two might differ because of memory allocation
+    ///   strategies: more memory than strictly necessary may be allocated for
+    ///   a given `sk_buff`)
     /// - the second number is the memory used by outgoing data. Note that
     ///   strictly UNIX sockets don't have a send queue, since the data they
     ///   send is directly written into the destination socket receive queue.
@@ -310,14 +310,16 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
                 let buf = VfsBuffer::new_checked(payload).context(err)?;
                 Self::Vfs(Vfs::parse(&buf).context(err)?)
             }
-            UNIX_DIAG_PEER => {
-                Self::Peer(parse_u32(payload).context("invalid UNIX_DIAG_PEER value")?)
-            }
+            UNIX_DIAG_PEER => Self::Peer(
+                parse_u32(payload).context("invalid UNIX_DIAG_PEER value")?,
+            ),
             UNIX_DIAG_ICONS => {
                 if payload.len() % 4 != 0 {
                     return Err(DecodeError::from("invalid UNIX_DIAG_ICONS"));
                 }
-                Self::PendingConnections(payload.chunks(4).map(NativeEndian::read_u32).collect())
+                Self::PendingConnections(
+                    payload.chunks(4).map(NativeEndian::read_u32).collect(),
+                )
             }
             UNIX_DIAG_RQLEN => {
                 if payload.len() != 8 {
@@ -333,12 +335,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
                 let buf = MemInfoBuffer::new_checked(payload).context(err)?;
                 Self::MemInfo(MemInfo::parse(&buf).context(err)?)
             }
-            UNIX_DIAG_SHUTDOWN => {
-                Self::Shutdown(parse_u8(payload).context("invalid UNIX_DIAG_SHUTDOWN value")?)
-            }
-            kind => {
-                Self::Other(DefaultNla::parse(buf).context(format!("unknown NLA type {}", kind))?)
-            }
+            UNIX_DIAG_SHUTDOWN => Self::Shutdown(
+                parse_u8(payload)
+                    .context("invalid UNIX_DIAG_SHUTDOWN value")?,
+            ),
+            kind => Self::Other(
+                DefaultNla::parse(buf)
+                    .context(format!("unknown NLA type {kind}"))?,
+            ),
         })
     }
 }

--- a/src/unix/nlas.rs
+++ b/src/unix/nlas.rs
@@ -2,15 +2,15 @@
 
 use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-
-pub use crate::utils::nla::{DefaultNla, NlaBuffer, NlasIterator};
-
-use crate::{
-    constants::*,
+use netlink_packet_utils::{
+    buffer,
+    nla::{self, DefaultNla, NlaBuffer},
     parsers::{parse_string, parse_u32, parse_u8},
     traits::{Emitable, Parseable},
     DecodeError,
 };
+
+use crate::constants::*;
 
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Nla {
@@ -242,7 +242,7 @@ impl Emitable for MemInfo {
     }
 }
 
-impl crate::utils::nla::Nla for Nla {
+impl nla::Nla for Nla {
     fn value_len(&self) -> usize {
         use self::Nla::*;
         match *self {

--- a/src/unix/request.rs
+++ b/src/unix/request.rs
@@ -85,7 +85,9 @@ bitflags! {
     }
 }
 
-impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixRequestBuffer<&'a T>> for UnixRequest {
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<UnixRequestBuffer<&'a T>>
+    for UnixRequest
+{
     fn parse(buf: &UnixRequestBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self {
             state_flags: StateFlags::from_bits_truncate(buf.state_flags()),

--- a/src/unix/request.rs
+++ b/src/unix/request.rs
@@ -2,11 +2,13 @@
 
 use std::convert::TryFrom;
 
-use crate::{
-    constants::*,
+use netlink_packet_utils::{
+    buffer,
     traits::{Emitable, Parseable},
     DecodeError,
 };
+
+use crate::constants::*;
 
 pub const UNIX_REQUEST_LEN: usize = 24;
 

--- a/src/unix/response.rs
+++ b/src/unix/response.rs
@@ -44,7 +44,9 @@ pub struct UnixResponseHeader {
     pub cookie: [u8; 8],
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>> for UnixResponseHeader {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>>
+    for UnixResponseHeader
+{
     fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         Ok(Self {
             kind: buf.kind(),
@@ -64,7 +66,7 @@ impl Emitable for UnixResponseHeader {
 
     fn emit(&self, buf: &mut [u8]) {
         let mut buf = UnixResponseBuffer::new(buf);
-        buf.set_family(AF_UNIX as u8);
+        buf.set_family(AF_UNIX);
         buf.set_kind(self.kind);
         buf.set_state(self.state);
         buf.set_pad(0);
@@ -182,12 +184,16 @@ impl UnixResponse {
 }
 
 impl<'a, T: AsRef<[u8]> + ?Sized> UnixResponseBuffer<&'a T> {
-    pub fn nlas(&self) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+    pub fn nlas(
+        &self,
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
         NlasIterator::new(self.payload())
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>> for SmallVec<[Nla; 8]> {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>>
+    for SmallVec<[Nla; 8]>
+{
     fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
         let mut nlas = smallvec![];
         for nla_buf in buf.nlas() {
@@ -197,12 +203,14 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>> for Small
     }
 }
 
-impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>> for UnixResponse {
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<UnixResponseBuffer<&'a T>>
+    for UnixResponse
+{
     fn parse(buf: &UnixResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
-        let header =
-            UnixResponseHeader::parse(buf).context("failed to parse inet response header")?;
-        let nlas =
-            SmallVec::<[Nla; 8]>::parse(buf).context("failed to parse inet response NLAs")?;
+        let header = UnixResponseHeader::parse(buf)
+            .context("failed to parse inet response header")?;
+        let nlas = SmallVec::<[Nla; 8]>::parse(buf)
+            .context("failed to parse inet response NLAs")?;
         Ok(UnixResponse { header, nlas })
     }
 }

--- a/src/unix/response.rs
+++ b/src/unix/response.rs
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use smallvec::SmallVec;
 use std::convert::TryFrom;
+
+use anyhow::Context;
+use netlink_packet_utils::{
+    buffer,
+    nla::{NlaBuffer, NlasIterator},
+    traits::{Emitable, Parseable},
+    DecodeError,
+};
+use smallvec::SmallVec;
 
 use crate::{
     constants::*,
-    traits::{Emitable, Parseable},
-    unix::nlas::{MemInfo, Nla, NlaBuffer, NlasIterator},
-    DecodeError,
+    unix::nlas::{MemInfo, Nla},
 };
 
 pub const UNIX_RESPONSE_HEADER_LEN: usize = 16;

--- a/src/unix/tests.rs
+++ b/src/unix/tests.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
 
+use netlink_packet_utils::traits::{Emitable, Parseable};
+
 use crate::{
     constants::*,
-    traits::{Emitable, Parseable},
     unix::{
         nlas::Nla, ShowFlags, StateFlags, UnixRequest, UnixResponse, UnixResponseBuffer,
         UnixResponseHeader,

--- a/src/unix/tests.rs
+++ b/src/unix/tests.rs
@@ -5,8 +5,8 @@ use netlink_packet_utils::traits::{Emitable, Parseable};
 use crate::{
     constants::*,
     unix::{
-        nlas::Nla, ShowFlags, StateFlags, UnixRequest, UnixResponse, UnixResponseBuffer,
-        UnixResponseHeader,
+        nlas::Nla, ShowFlags, StateFlags, UnixRequest, UnixResponse,
+        UnixResponseBuffer, UnixResponseHeader,
     },
 };
 
@@ -75,9 +75,10 @@ static LISTENING_BUF: [u8; 60] = [
 
 #[test]
 fn parse_listening() {
-    let parsed =
-        UnixResponse::parse(&UnixResponseBuffer::new_checked(&&LISTENING_BUF[..]).unwrap())
-            .unwrap();
+    let parsed = UnixResponse::parse(
+        &UnixResponseBuffer::new_checked(&&LISTENING_BUF[..]).unwrap(),
+    )
+    .unwrap();
     assert_eq!(parsed, *LISTENING);
 }
 
@@ -142,9 +143,10 @@ static ESTABLISHED_BUF: [u8; 68] = [
 
 #[test]
 fn parse_established() {
-    let parsed =
-        UnixResponse::parse(&UnixResponseBuffer::new_checked(&&ESTABLISHED_BUF[..]).unwrap())
-            .unwrap();
+    let parsed = UnixResponse::parse(
+        &UnixResponseBuffer::new_checked(&&ESTABLISHED_BUF[..]).unwrap(),
+    )
+    .unwrap();
     assert_eq!(parsed, *ESTABLISHED);
 }
 


### PR DESCRIPTION
Removed these reexports:
 * `netlink_packet_sock_diag::traits`
 * `netlink_packet_sock_diag::DecodeError`
 * `netlink_packet_sock_diag::ErrorMessage`
 * `netlink_packet_sock_diag::NetlinkBuffer`
 * `netlink_packet_sock_diag::NetlinkHeader`
 * `netlink_packet_sock_diag::NetlinkMessage`
 * `netlink_packet_sock_diag::NetlinkPayload`
 * Constants from `netlink_packet_core` are removed from
   `netlink_packet_sock_diag::constants`.