### PR TITLE
New release 0.4.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,10 @@
+# Changelog
+## [0.4.0] - 2023-01-29
+### Breaking changes
+ - Removed all reexports. (e3bb0f0)
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (1c0c9a8)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,8 @@
 [package]
 authors = ["Flier Lu <flier.lu@gmail.com>", "Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-sock-diag"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2018"
-
 homepage = "https://github.com/rust-netlink/netlink-packet-sock-diag"
 keywords = ["netlink", "linux", "sock_diag"]
 license = "MIT"


### PR DESCRIPTION
=== Breaking changes
 - Removed all reexports. (e3bb0f0)

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (1c0c9a8)