### PR TITLE
New release 0.4.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,14 @@
 # Changelog
+## [0.4.2] - 2023-07-10
+### Breaking changes
+ - N/A
+
+### New features
+ - N/A
+
+### Bug fixes
+ - Use latest rust-netlink crates. (0bff837)
+
 ## [0.4.1] - 2023-01-29
 ### Breaking changes
  - N/A

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["Flier Lu <flier.lu@gmail.com>", "Corentin Henry <corentinhenry@gmail.com>"]
 name = "netlink-packet-sock-diag"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2018"
 homepage = "https://github.com/rust-netlink/netlink-packet-sock-diag"
 keywords = ["netlink", "linux", "sock_diag"]


### PR DESCRIPTION
=== Breaking changes
 - N/A

=== New features
 - N/A

=== Bug fixes
 - Use latest rust-netlink crates. (0bff837)