### PR TITLE
diag: add support for SOCK_DESTROY

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -8,7 +8,7 @@ use netlink_packet_utils::{
     DecodeError,
 };
 
-use crate::{inet, unix, SockDiagBuffer, SOCK_DIAG_BY_FAMILY};
+use crate::{inet, unix, SockDiagBuffer, SOCK_DESTROY, SOCK_DIAG_BY_FAMILY};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SockDiagMessage {
@@ -90,6 +90,47 @@ impl NetlinkDeserializable for SockDiagMessage {
 
 impl From<SockDiagMessage> for NetlinkPayload<SockDiagMessage> {
     fn from(message: SockDiagMessage) -> Self {
+        NetlinkPayload::InnerMessage(message)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SockDiagDestroy(SockDiagMessage);
+
+impl SockDiagDestroy {
+    pub fn new(message: SockDiagMessage) -> SockDiagDestroy {
+        SockDiagDestroy(message)
+    }
+}
+
+impl NetlinkSerializable for SockDiagDestroy {
+    fn message_type(&self) -> u16 {
+        SOCK_DESTROY
+    }
+
+    fn buffer_len(&self) -> usize {
+        NetlinkSerializable::buffer_len(&self.0)
+    }
+
+    fn serialize(&self, buffer: &mut [u8]) {
+        self.0.serialize(buffer)
+    }
+}
+
+impl NetlinkDeserializable for SockDiagDestroy {
+    type Error = DecodeError;
+    fn deserialize(
+        header: &NetlinkHeader,
+        payload: &[u8],
+    ) -> Result<Self, Self::Error> {
+        Ok(SockDiagDestroy::new(SockDiagMessage::deserialize(
+            header, payload,
+        )?))
+    }
+}
+
+impl From<SockDiagDestroy> for NetlinkPayload<SockDiagDestroy> {
+    fn from(message: SockDiagDestroy) -> Self {
         NetlinkPayload::InnerMessage(message)
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -5,7 +5,7 @@ use netlink_packet_core::{
     NetlinkPayload, NetlinkSerializable, ParseableParametrized,
 };
 
-use crate::{inet, unix, SockDiagBuffer, SOCK_DIAG_BY_FAMILY};
+use crate::{inet, unix, SockDiagBuffer, SOCK_DESTROY, SOCK_DIAG_BY_FAMILY};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SockDiagMessage {
@@ -87,6 +87,47 @@ impl NetlinkDeserializable for SockDiagMessage {
 
 impl From<SockDiagMessage> for NetlinkPayload<SockDiagMessage> {
     fn from(message: SockDiagMessage) -> Self {
+        NetlinkPayload::InnerMessage(message)
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct SockDiagDestroy(SockDiagMessage);
+
+impl SockDiagDestroy {
+    pub fn new(message: SockDiagMessage) -> SockDiagDestroy {
+        SockDiagDestroy(message)
+    }
+}
+
+impl NetlinkSerializable for SockDiagDestroy {
+    fn message_type(&self) -> u16 {
+        SOCK_DESTROY
+    }
+
+    fn buffer_len(&self) -> usize {
+        NetlinkSerializable::buffer_len(&self.0)
+    }
+
+    fn serialize(&self, buffer: &mut [u8]) {
+        self.0.serialize(buffer)
+    }
+}
+
+impl NetlinkDeserializable for SockDiagDestroy {
+    type Error = DecodeError;
+    fn deserialize(
+        header: &NetlinkHeader,
+        payload: &[u8],
+    ) -> Result<Self, Self::Error> {
+        Ok(SockDiagDestroy::new(SockDiagMessage::deserialize(
+            header, payload,
+        )?))
+    }
+}
+
+impl From<SockDiagDestroy> for NetlinkPayload<SockDiagDestroy> {
+    fn from(message: SockDiagDestroy) -> Self {
         NetlinkPayload::InnerMessage(message)
     }
 }


### PR DESCRIPTION
It is implemented on top of SockDiagMessage, and allows using Linux's CONFIG_INET_DIAG_DESTROY feature to close an arbitrary socket.

A long running, but buggy process might have hanging sockets kept alive by error. Using SOCK_DESTROY allows closing arbitrary sockets as root; an example tool that uses this feature and this crate is at: https://github.com/anisse/tcpkill

This PR should replace this one: https://github.com/little-dude/netlink/pull/283