### PR TITLE
Fix dump_ipv4 example

### DIFF
--- a/examples/dump_ipv4.rs
+++ b/examples/dump_ipv4.rs
@@ -56,13 +56,13 @@ fn main() {
             println!("<<< {rx_packet:?}");
 
             match rx_packet.payload {
-                NetlinkPayload::Noop | NetlinkPayload::Ack(_) => {}
+                NetlinkPayload::Noop => {}
                 NetlinkPayload::InnerMessage(
                     SockDiagMessage::InetResponse(response),
                 ) => {
                     println!("{response:#?}");
                 }
-                NetlinkPayload::Done => {
+                NetlinkPayload::Done(_) => {
                     println!("Done!");
                     return;
                 }


### PR DESCRIPTION
`dump_ipv4` example fails to build due to breaking changes in `netlink-packet-core`. Update as needed.