### PR TITLE
Upgrade netlink-packet-core to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,6 @@ description = "netlink packet types for the sock_diag subprotocol"
 rich_nlas = []
 
 [dependencies]
-byteorder = "1.3.4"
 netlink-packet-core = "0.8"
 bitflags = "2"
 libc = "0.2.77"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.32"
 byteorder = "1.3.4"
 netlink-packet-core = { version = "0.7.0" }
 netlink-packet-utils = { version = "0.5.2" }
-bitflags = "1.2.1"
+bitflags = "2"
 libc = "0.2.77"
 smallvec = "1.4.2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,8 @@ description = "netlink packet types for the sock_diag subprotocol"
 rich_nlas = []
 
 [dependencies]
-anyhow = "1.0.32"
 byteorder = "1.3.4"
-netlink-packet-core = { version = "0.7.0" }
-netlink-packet-utils = { version = "0.5.2" }
+netlink-packet-core = "0.8"
 bitflags = "2"
 libc = "0.2.77"
 smallvec = "1.4.2"

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    traits::{Parseable, ParseableParametrized},
-    DecodeError,
+use netlink_packet_core::{
+    DecodeError, ErrorContext, Parseable, ParseableParametrized,
 };
 
 use crate::{constants::*, inet, unix, SockDiagMessage};

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -228,6 +228,7 @@ pub const SOCK_RAW: u8 = libc::SOCK_RAW as u8;
 /// Provides a reliable datagram layer that does not guarantee
 /// ordering.
 pub const SOCK_RDM: u8 = libc::SOCK_RDM as u8;
+#[allow(deprecated)]
 /// Obsolete and should not be used in new programs; see `packet(7)`.
 pub const SOCK_PACKET: u8 = libc::SOCK_PACKET as u8;
 

--- a/src/inet/nlas.rs
+++ b/src/inet/nlas.rs
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
 
-use netlink_packet_utils::{
-    buffer,
-    nla::{self, DefaultNla, NlaBuffer},
-    parsers::{parse_string, parse_u32, parse_u8},
-    traits::{Emitable, Parseable},
-    DecodeError,
+use netlink_packet_core::{
+    buffer, fields, getter, parse_string, parse_u32, parse_u8, setter,
+    DecodeError, DefaultNla, Emitable, ErrorContext, NlaBuffer, Parseable,
 };
 
 use crate::constants::*;
@@ -252,7 +248,7 @@ pub enum Nla {
     Other(DefaultNla),
 }
 
-impl nla::Nla for Nla {
+impl netlink_packet_core::Nla for Nla {
     fn value_len(&self) -> usize {
         use self::Nla::*;
         match *self {

--- a/src/inet/nlas.rs
+++ b/src/inet/nlas.rs
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use byteorder::{ByteOrder, NativeEndian};
-
 use netlink_packet_core::{
-    buffer, fields, getter, parse_string, parse_u32, parse_u8, setter,
-    DecodeError, DefaultNla, Emitable, ErrorContext, NlaBuffer, Parseable,
+    buffer, emit_u32, fields, getter, parse_string, parse_u32, parse_u8,
+    setter, DecodeError, DefaultNla, Emitable, ErrorContext, NlaBuffer,
+    Parseable,
 };
 
 use crate::constants::*;
@@ -301,9 +300,7 @@ impl netlink_packet_core::Nla for Nla {
             Tos(b) | Tc(b) | Shutdown(b) | Protocol(b) => buffer[0] = b,
             SkV6Only(value) => buffer[0] = value.into(),
             MemInfo(ref value) => value.emit(buffer),
-            Mark(value) | ClassId(value) => {
-                NativeEndian::write_u32(buffer, value)
-            }
+            Mark(value) | ClassId(value) => emit_u32(buffer, value).unwrap(),
             Other(ref attr) => attr.emit_value(buffer),
         }
     }

--- a/src/inet/request.rs
+++ b/src/inet/request.rs
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    buffer,
-    traits::{Emitable, Parseable, ParseableParametrized},
-    DecodeError,
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Emitable, ErrorContext,
+    Parseable, ParseableParametrized,
 };
 
 use crate::{

--- a/src/inet/request.rs
+++ b/src/inet/request.rs
@@ -48,6 +48,7 @@ pub struct InetRequest {
 
 bitflags! {
     /// Bitmask that defines a filter of TCP socket states
+    #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct StateFlags: u32 {
         /// (server and client) represents an open connection,
         /// data received can be delivered to the user. The normal
@@ -96,6 +97,7 @@ bitflags! {
 bitflags! {
     /// This is a set of flags defining what kind of extended
     /// information to report.
+    #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct ExtensionFlags: u8 {
         const MEMINFO = 1 << (INET_DIAG_MEMINFO - 1);
         const INFO = 1 << (INET_DIAG_INFO - 1);

--- a/src/inet/response.rs
+++ b/src/inet/response.rs
@@ -2,12 +2,9 @@
 
 use std::time::Duration;
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    buffer,
-    nla::{NlaBuffer, NlasIterator},
-    traits::{Emitable, Parseable, ParseableParametrized},
-    DecodeError,
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Emitable, ErrorContext,
+    NlaBuffer, NlasIterator, Parseable, ParseableParametrized,
 };
 use smallvec::SmallVec;
 

--- a/src/inet/socket_id.rs
+++ b/src/inet/socket_id.rs
@@ -6,10 +6,9 @@ use std::{
 };
 
 use byteorder::{BigEndian, ByteOrder};
-use netlink_packet_utils::{
-    buffer,
-    traits::{Emitable, ParseableParametrized},
-    DecodeError,
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Emitable,
+    ParseableParametrized,
 };
 
 use crate::constants::*;

--- a/src/inet/socket_id.rs
+++ b/src/inet/socket_id.rs
@@ -5,10 +5,9 @@ use std::{
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
 };
 
-use byteorder::{BigEndian, ByteOrder};
 use netlink_packet_core::{
-    buffer, fields, getter, setter, DecodeError, Emitable,
-    ParseableParametrized,
+    buffer, emit_u16_be, fields, getter, parse_u16_be, setter, DecodeError,
+    Emitable, ParseableParametrized,
 };
 
 use crate::constants::*;
@@ -98,8 +97,8 @@ impl<'a, T: AsRef<[u8]> + 'a> ParseableParametrized<SocketIdBuffer<&'a T>, u8>
         };
 
         Ok(Self {
-            source_port: BigEndian::read_u16(buf.source_port()),
-            destination_port: BigEndian::read_u16(buf.destination_port()),
+            source_port: parse_u16_be(buf.source_port())?,
+            destination_port: parse_u16_be(buf.destination_port())?,
             source_address,
             destination_address,
             interface_id: buf.interface_id(),
@@ -118,11 +117,9 @@ impl Emitable for SocketId {
     fn emit(&self, buffer: &mut [u8]) {
         let mut buffer = SocketIdBuffer::new(buffer);
 
-        BigEndian::write_u16(buffer.source_port_mut(), self.source_port);
-        BigEndian::write_u16(
-            buffer.destination_port_mut(),
-            self.destination_port,
-        );
+        emit_u16_be(buffer.source_port_mut(), self.source_port).unwrap();
+        emit_u16_be(buffer.destination_port_mut(), self.destination_port)
+            .unwrap();
 
         let mut address_buf: [u8; 16] = [0; 16];
         match self.source_address {

--- a/src/inet/tests.rs
+++ b/src/inet/tests.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use netlink_packet_utils::traits::{Emitable, Parseable};
+use netlink_packet_core::{Emitable, Parseable};
 
 use crate::{
     constants::*,

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,11 +1,8 @@
 // SPDX-License-Identifier: MIT
 
 use netlink_packet_core::{
-    NetlinkDeserializable, NetlinkHeader, NetlinkPayload, NetlinkSerializable,
-};
-use netlink_packet_utils::{
-    traits::{Emitable, ParseableParametrized},
-    DecodeError,
+    DecodeError, Emitable, NetlinkDeserializable, NetlinkHeader,
+    NetlinkPayload, NetlinkSerializable, ParseableParametrized,
 };
 
 use crate::{inet, unix, SockDiagBuffer, SOCK_DIAG_BY_FAMILY};

--- a/src/unix/nlas.rs
+++ b/src/unix/nlas.rs
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use anyhow::Context;
 use byteorder::{ByteOrder, NativeEndian};
-use netlink_packet_utils::{
-    buffer,
-    nla::{self, DefaultNla, NlaBuffer},
-    parsers::{parse_string, parse_u32, parse_u8},
-    traits::{Emitable, Parseable},
-    DecodeError,
+use netlink_packet_core::{
+    buffer, fields, getter, parse_string, parse_u32, parse_u8, setter,
+    DecodeError, DefaultNla, Emitable, ErrorContext, NlaBuffer, Parseable,
 };
 
 use crate::constants::*;
@@ -242,7 +238,7 @@ impl Emitable for MemInfo {
     }
 }
 
-impl nla::Nla for Nla {
+impl netlink_packet_core::Nla for Nla {
     fn value_len(&self) -> usize {
         use self::Nla::*;
         match *self {

--- a/src/unix/nlas.rs
+++ b/src/unix/nlas.rs
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 
-use byteorder::{ByteOrder, NativeEndian};
 use netlink_packet_core::{
-    buffer, fields, getter, parse_string, parse_u32, parse_u8, setter,
-    DecodeError, DefaultNla, Emitable, ErrorContext, NlaBuffer, Parseable,
+    buffer, emit_u32, fields, getter, parse_string, parse_u32, parse_u8,
+    setter, DecodeError, DefaultNla, Emitable, ErrorContext, NlaBuffer,
+    Parseable,
 };
 
 use crate::constants::*;
@@ -262,15 +262,15 @@ impl netlink_packet_core::Nla for Nla {
                 buffer[s.len()] = 0;
             }
             Vfs(ref value) => value.emit(buffer),
-            Peer(value) => NativeEndian::write_u32(buffer, value),
+            Peer(value) => emit_u32(buffer, value).unwrap(),
             PendingConnections(ref values) => {
                 for (i, v) in values.iter().enumerate() {
-                    NativeEndian::write_u32(&mut buffer[i * 4..], *v);
+                    emit_u32(&mut buffer[i * 4..], *v).unwrap();
                 }
             }
             ReceiveQueueLength(v1, v2) => {
-                NativeEndian::write_u32(buffer, v1);
-                NativeEndian::write_u32(&mut buffer[4..], v2);
+                emit_u32(buffer, v1).unwrap();
+                emit_u32(&mut buffer[4..], v2).unwrap();
             }
             MemInfo(ref value) => value.emit(buffer),
             Shutdown(value) => buffer[0] = value,
@@ -314,7 +314,7 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
                     return Err(DecodeError::from("invalid UNIX_DIAG_ICONS"));
                 }
                 Self::PendingConnections(
-                    payload.chunks(4).map(NativeEndian::read_u32).collect(),
+                    payload.chunks(4).map(|b| parse_u32(b).unwrap()).collect(),
                 )
             }
             UNIX_DIAG_RQLEN => {
@@ -322,8 +322,8 @@ impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
                     return Err(DecodeError::from("invalid UNIX_DIAG_RQLEN"));
                 }
                 Self::ReceiveQueueLength(
-                    NativeEndian::read_u32(&payload[..4]),
-                    NativeEndian::read_u32(&payload[4..]),
+                    parse_u32(&payload[..4])?,
+                    parse_u32(&payload[4..])?,
                 )
             }
             UNIX_DIAG_MEMINFO => {

--- a/src/unix/request.rs
+++ b/src/unix/request.rs
@@ -2,10 +2,8 @@
 
 use std::convert::TryFrom;
 
-use netlink_packet_utils::{
-    buffer,
-    traits::{Emitable, Parseable},
-    DecodeError,
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Emitable, Parseable,
 };
 
 use crate::constants::*;

--- a/src/unix/request.rs
+++ b/src/unix/request.rs
@@ -66,6 +66,7 @@ pub struct UnixRequest {
 
 bitflags! {
     /// Bitmask that defines a filter of UNIX socket states
+    #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct StateFlags: u32 {
         const ESTABLISHED = 1 << TCP_ESTABLISHED;
         const LISTEN = 1 << TCP_LISTEN;
@@ -75,6 +76,7 @@ bitflags! {
 bitflags! {
     /// Bitmask that defines what kind of information to
     /// report. Supported values are the `UDIAG_SHOW_*` constants.
+    #[derive(Debug, PartialEq, Eq, Clone)]
     pub struct ShowFlags: u32 {
         const NAME = UDIAG_SHOW_NAME;
         const VFS = UDIAG_SHOW_VFS;

--- a/src/unix/response.rs
+++ b/src/unix/response.rs
@@ -2,12 +2,9 @@
 
 use std::convert::TryFrom;
 
-use anyhow::Context;
-use netlink_packet_utils::{
-    buffer,
-    nla::{NlaBuffer, NlasIterator},
-    traits::{Emitable, Parseable},
-    DecodeError,
+use netlink_packet_core::{
+    buffer, fields, getter, setter, DecodeError, Emitable, ErrorContext,
+    NlaBuffer, NlasIterator, Parseable,
 };
 use smallvec::SmallVec;
 

--- a/src/unix/tests.rs
+++ b/src/unix/tests.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-use netlink_packet_utils::traits::{Emitable, Parseable};
+use netlink_packet_core::{Emitable, Parseable};
 
 use crate::{
     constants::*,


### PR DESCRIPTION
I tried using both `netlink-packet-sock-diag` and `netlink-packet-route`, and ended up with problems due to multiple versions of the `core` library being present. This PR updates the `core` library.