### PR TITLE
feat: add support for gathering `netlink` sockets information

### DIFF
--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -6,7 +6,7 @@ use netlink_packet_utils::{
     DecodeError,
 };
 
-use crate::{constants::*, inet, unix, SockDiagMessage};
+use crate::{constants::*, inet, netlink, unix, SockDiagMessage};
 
 const BUF_MIN_LEN: usize = 2;
 
@@ -89,6 +89,15 @@ impl<'a, T: AsRef<[u8]>> ParseableParametrized<SockDiagBuffer<&'a T>, u16>
                     .context(err)?;
                 UnixResponse(Box::new(
                     unix::UnixResponse::parse(&buf).context(err)?,
+                ))
+            }
+            (SOCK_DIAG_BY_FAMILY, AF_NETLINK) => {
+                let err = "invalid AF_NETLINK response";
+                let buf =
+                    netlink::NetlinkResponseBuffer::new_checked(buf.inner())
+                        .context(err)?;
+                NetlinkResponse(Box::new(
+                    netlink::NetlinkResponse::parse(&buf).context(err)?,
                 ))
             }
             (SOCK_DIAG_BY_FAMILY, af) => {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -211,6 +211,138 @@ pub const UNIX_DIAG_RQLEN: u16 = 4;
 pub const UNIX_DIAG_MEMINFO: u16 = 5;
 pub const UNIX_DIAG_SHUTDOWN: u16 = 6;
 
+pub const NDIAG_PROTO_ALL: u16 = 255;
+
+/// Show memory info of a socket.
+pub const NDIAG_SHOW_MEMINFO: u32 = 1;
+/// Show groups of a netlink socket.
+pub const NDIAG_SHOW_GROUPS: u32 = 2;
+/// Show ring configuration (deprecated since 4.6).
+pub const NDIAG_SHOW_RING_CFG: u32 = 4;
+/// Show flags of a netlink socket.
+pub const NDIAG_SHOW_FLAGS: u32 = 8;
+
+pub const NETLINK_DIAG_MEMINFO: u16 = 0;
+pub const NETLINK_DIAG_GROUPS: u16 = 1;
+pub const NETLINK_DIAG_RX_RING: u16 = 2;
+pub const NETLINK_DIAG_TX_RING: u16 = 3;
+pub const NETLINK_DIAG_FLAGS: u16 = 4;
+
+pub const NETLINK_UNCONNECTED: u8 = 0;
+pub const NETLINK_CONNECTED: u8 = 1;
+
+pub const NDIAG_FLAG_CB_RUNNING: u32 = 1;
+pub const NDIAG_FLAG_PKTINFO: u32 = 2;
+pub const NDIAG_FLAG_BROADCAST_ERROR: u32 = 4;
+pub const NDIAG_FLAG_NO_ENOBUFS: u32 = 8;
+pub const NDIAG_FLAG_LISTEN_ALL_NSID: u32 = 16;
+pub const NDIAG_FLAG_CAP_ACK: u32 = 32;
+
+/// Receives routing and link updates and may be used to modify the routing
+/// tables (both IPv4 and IPv6), IP addresses, link parameters, neighbor setups,
+/// queueing disciplines, traffic classes and packet  classifiers  (see
+/// rtnetlink(7)).
+pub const NETLINK_ROUTE: u8 = libc::NETLINK_ROUTE as u8;
+pub const NETLINK_UNUSED: u8 = libc::NETLINK_UNUSED as u8;
+/// Reserved for user-mode socket protocols.
+pub const NETLINK_USERSOCK: u8 = libc::NETLINK_USERSOCK as u8;
+/// Transport  IPv4  packets  from  netfilter  to  user  space.  Used by
+/// ip_queue kernel module. After a long period of being declared obsolete (in
+/// favor of the more advanced nfnetlink_queue feature), it was  removed in
+/// Linux 3.5.
+pub const NETLINK_FIREWALL: u8 = libc::NETLINK_FIREWALL as u8;
+/// Query information about sockets of various protocol families from the kernel
+/// (see sock_diag(7)).
+pub const NETLINK_SOCK_DIAG: u8 = libc::NETLINK_SOCK_DIAG as u8;
+/// Netfilter/iptables ULOG.
+pub const NETLINK_NFLOG: u8 = libc::NETLINK_NFLOG as u8;
+/// IPsec.
+pub const NETLINK_XFRM: u8 = libc::NETLINK_XFRM as u8;
+/// SELinux event notifications.
+pub const NETLINK_SELINUX: u8 = libc::NETLINK_SELINUX as u8;
+/// Open-iSCSI.
+pub const NETLINK_ISCSI: u8 = libc::NETLINK_ISCSI as u8;
+/// Auditing.
+pub const NETLINK_AUDIT: u8 = libc::NETLINK_AUDIT as u8;
+/// Access to FIB lookup from user space.
+pub const NETLINK_FIB_LOOKUP: u8 = libc::NETLINK_FIB_LOOKUP as u8;
+/// Kernel connector. See `Documentation/connector/*` in the Linux kernel source
+/// tree for further information.
+pub const NETLINK_CONNECTOR: u8 = libc::NETLINK_CONNECTOR as u8;
+/// Netfilter subsystem.
+pub const NETLINK_NETFILTER: u8 = libc::NETLINK_NETFILTER as u8;
+/// Transport IPv6 packets from netfilter to user space.  Used by ip6_queue
+/// kernel module.
+pub const NETLINK_IP6_FW: u8 = libc::NETLINK_IP6_FW as u8;
+/// DECnet routing messages.
+pub const NETLINK_DNRTMSG: u8 = libc::NETLINK_DNRTMSG as u8;
+/// Kernel messages to user space.
+pub const NETLINK_KOBJECT_UEVENT: u8 = libc::NETLINK_KOBJECT_UEVENT as u8;
+///  Generic netlink family for simplified netlink usage.
+pub const NETLINK_GENERIC: u8 = libc::NETLINK_GENERIC as u8;
+/// SCSI Transports.
+pub const NETLINK_SCSITRANSPORT: u8 = libc::NETLINK_SCSITRANSPORT as u8;
+pub const NETLINK_ECRYPTFS: u8 = libc::NETLINK_ECRYPTFS as u8;
+/// Infiniband RDMA.
+pub const NETLINK_RDMA: u8 = libc::NETLINK_RDMA as u8;
+/// Netlink interface to request information about ciphers registered with the
+/// kernel crypto API as well as allow configuration of the kernel crypto API.
+pub const NETLINK_CRYPTO: u8 = libc::NETLINK_CRYPTO as u8;
+
+pub const RTMGRP_LINK: u32 = libc::RTMGRP_LINK as u32;
+pub const RTMGRP_NOTIFY: u32 = libc::RTMGRP_NOTIFY as u32;
+pub const RTMGRP_NEIGH: u32 = libc::RTMGRP_NEIGH as u32;
+pub const RTMGRP_TC: u32 = libc::RTMGRP_TC as u32;
+pub const RTMGRP_IPV4_IFADDR: u32 = libc::RTMGRP_IPV4_IFADDR as u32;
+pub const RTMGRP_IPV4_MROUTE: u32 = libc::RTMGRP_IPV4_MROUTE as u32;
+pub const RTMGRP_IPV4_ROUTE: u32 = libc::RTMGRP_IPV4_ROUTE as u32;
+pub const RTMGRP_IPV4_RULE: u32 = libc::RTMGRP_IPV4_RULE as u32;
+pub const RTMGRP_IPV6_IFADDR: u32 = libc::RTMGRP_IPV6_IFADDR as u32;
+pub const RTMGRP_IPV6_MROUTE: u32 = libc::RTMGRP_IPV6_MROUTE as u32;
+pub const RTMGRP_IPV6_ROUTE: u32 = libc::RTMGRP_IPV6_ROUTE as u32;
+pub const RTMGRP_IPV6_IFINFO: u32 = libc::RTMGRP_IPV6_IFINFO as u32;
+pub const RTMGRP_DECNET_IFADDR: u32 = libc::RTMGRP_DECnet_IFADDR as u32;
+pub const RTMGRP_DECNET_ROUTE: u32 = libc::RTMGRP_DECnet_ROUTE as u32;
+pub const RTMGRP_IPV6_PREFIX: u32 = libc::RTMGRP_IPV6_PREFIX as u32;
+
+// pub const RTNLGRP_NONE: u32 = libc::RTNLGRP_NONE as u32;
+pub const RTNLGRP_LINK: u32 = libc::RTNLGRP_LINK as u32;
+pub const RTNLGRP_NOTIFY: u32 = libc::RTNLGRP_NOTIFY as u32;
+pub const RTNLGRP_NEIGH: u32 = libc::RTNLGRP_NEIGH as u32;
+pub const RTNLGRP_TC: u32 = libc::RTNLGRP_TC as u32;
+pub const RTNLGRP_IPV4_IFADDR: u32 = libc::RTNLGRP_IPV4_IFADDR as u32;
+pub const RTNLGRP_IPV4_MROUTE: u32 = libc::RTNLGRP_IPV4_MROUTE as u32;
+pub const RTNLGRP_IPV4_ROUTE: u32 = libc::RTNLGRP_IPV4_ROUTE as u32;
+pub const RTNLGRP_IPV4_RULE: u32 = libc::RTNLGRP_IPV4_RULE as u32;
+pub const RTNLGRP_IPV6_IFADDR: u32 = libc::RTNLGRP_IPV6_IFADDR as u32;
+pub const RTNLGRP_IPV6_MROUTE: u32 = libc::RTNLGRP_IPV6_MROUTE as u32;
+pub const RTNLGRP_IPV6_ROUTE: u32 = libc::RTNLGRP_IPV6_ROUTE as u32;
+pub const RTNLGRP_IPV6_IFINFO: u32 = libc::RTNLGRP_IPV6_IFINFO as u32;
+pub const RTNLGRP_DECNET_IFADDR: u32 = libc::RTNLGRP_DECnet_IFADDR as u32;
+// pub const RTNLGRP_NOP2: u32 = libc::RTNLGRP_NOP2 as u32;
+pub const RTNLGRP_DECNET_ROUTE: u32 = libc::RTNLGRP_DECnet_ROUTE as u32;
+pub const RTNLGRP_DECNET_RULE: u32 = libc::RTNLGRP_DECnet_RULE as u32;
+// pub const RTNLGRP_NOP4: u32 = libc::RTNLGRP_NOP4 as u32;
+pub const RTNLGRP_IPV6_PREFIX: u32 = libc::RTNLGRP_IPV6_PREFIX as u32;
+pub const RTNLGRP_IPV6_RULE: u32 = libc::RTNLGRP_IPV6_RULE as u32;
+pub const RTNLGRP_ND_USEROPT: u32 = libc::RTNLGRP_ND_USEROPT as u32;
+pub const RTNLGRP_PHONET_IFADDR: u32 = libc::RTNLGRP_PHONET_IFADDR as u32;
+pub const RTNLGRP_PHONET_ROUTE: u32 = libc::RTNLGRP_PHONET_ROUTE as u32;
+pub const RTNLGRP_DCB: u32 = libc::RTNLGRP_DCB as u32;
+pub const RTNLGRP_IPV4_NETCONF: u32 = libc::RTNLGRP_IPV4_NETCONF as u32;
+pub const RTNLGRP_IPV6_NETCONF: u32 = libc::RTNLGRP_IPV6_NETCONF as u32;
+pub const RTNLGRP_MDB: u32 = libc::RTNLGRP_MDB as u32;
+pub const RTNLGRP_MPLS_ROUTE: u32 = libc::RTNLGRP_MPLS_ROUTE as u32;
+pub const RTNLGRP_NSID: u32 = libc::RTNLGRP_NSID as u32;
+pub const RTNLGRP_MPLS_NETCONF: u32 = libc::RTNLGRP_MPLS_NETCONF as u32;
+pub const RTNLGRP_IPV4_MROUTE_R: u32 = libc::RTNLGRP_IPV4_MROUTE_R as u32;
+pub const RTNLGRP_IPV6_MROUTE_R: u32 = libc::RTNLGRP_IPV6_MROUTE_R as u32;
+pub const RTNLGRP_NEXTHOP: u32 = libc::RTNLGRP_NEXTHOP as u32;
+pub const RTNLGRP_BRVLAN: u32 = libc::RTNLGRP_BRVLAN as u32;
+pub const RTNLGRP_MCTP_IFADDR: u32 = libc::RTNLGRP_MCTP_IFADDR as u32;
+pub const RTNLGRP_TUNNEL: u32 = libc::RTNLGRP_TUNNEL as u32;
+pub const RTNLGRP_STATS: u32 = libc::RTNLGRP_STATS as u32;
+
 /// Provides sequenced, reliable, two-way, connection-based byte
 /// streams. An out-of-band data transmission mechanism may be
 /// supported.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,5 +14,6 @@ pub mod buffer;
 pub mod constants;
 pub mod inet;
 pub mod message;
+pub mod netlink;
 pub mod unix;
 pub use self::{buffer::*, constants::*, message::*};

--- a/src/message.rs
+++ b/src/message.rs
@@ -8,7 +8,7 @@ use netlink_packet_utils::{
     DecodeError,
 };
 
-use crate::{inet, unix, SockDiagBuffer, SOCK_DIAG_BY_FAMILY};
+use crate::{inet, netlink, unix, SockDiagBuffer, SOCK_DIAG_BY_FAMILY};
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SockDiagMessage {
@@ -16,6 +16,8 @@ pub enum SockDiagMessage {
     InetResponse(Box<inet::InetResponse>),
     UnixRequest(unix::UnixRequest),
     UnixResponse(Box<unix::UnixResponse>),
+    NetlinkRequest(netlink::NetlinkRequest),
+    NetlinkResponse(Box<netlink::NetlinkResponse>),
 }
 
 impl SockDiagMessage {
@@ -26,12 +28,21 @@ impl SockDiagMessage {
     pub fn is_inet_response(&self) -> bool {
         matches!(self, SockDiagMessage::InetResponse(_))
     }
+
     pub fn is_unix_request(&self) -> bool {
         matches!(self, SockDiagMessage::UnixRequest(_))
     }
 
     pub fn is_unix_response(&self) -> bool {
         matches!(self, SockDiagMessage::UnixResponse(_))
+    }
+
+    pub fn is_netlink_request(&self) -> bool {
+        matches!(self, SockDiagMessage::NetlinkRequest(_))
+    }
+
+    pub fn is_netlink_response(&self) -> bool {
+        matches!(self, SockDiagMessage::NetlinkResponse(_))
     }
 
     pub fn message_type(&self) -> u16 {
@@ -48,6 +59,8 @@ impl Emitable for SockDiagMessage {
             InetResponse(ref msg) => msg.buffer_len(),
             UnixRequest(ref msg) => msg.buffer_len(),
             UnixResponse(ref msg) => msg.buffer_len(),
+            NetlinkRequest(ref msg) => msg.buffer_len(),
+            NetlinkResponse(ref msg) => msg.buffer_len(),
         }
     }
 
@@ -59,6 +72,8 @@ impl Emitable for SockDiagMessage {
             InetResponse(ref msg) => msg.emit(buffer),
             UnixRequest(ref msg) => msg.emit(buffer),
             UnixResponse(ref msg) => msg.emit(buffer),
+            NetlinkRequest(ref msg) => msg.emit(buffer),
+            NetlinkResponse(ref msg) => msg.emit(buffer),
         }
     }
 }

--- a/src/netlink/mod.rs
+++ b/src/netlink/mod.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+mod request;
+pub use self::request::*;
+
+mod response;
+pub use self::response::*;
+
+pub mod nlas;
+
+#[cfg(test)]
+mod tests;

--- a/src/netlink/nlas.rs
+++ b/src/netlink/nlas.rs
@@ -1,0 +1,356 @@
+// SPDX-License-Identifier: MIT
+
+use crate::constants::*;
+use anyhow::Context;
+use byteorder::{ByteOrder, NativeEndian, WriteBytesExt};
+use netlink_packet_utils::{
+    buffer,
+    nla::{self, DefaultNla, NlaBuffer},
+    traits::{Emitable, Parseable},
+    DecodeError,
+};
+use smallvec::SmallVec;
+use std::io::Cursor;
+use std::iter::FromIterator;
+use std::mem::size_of;
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum Nla {
+    /// Socket memory information. This attribute is known as
+    /// `NETLINK_DIAG_MEMINFO` in the kernel. See [MemInfo] for more
+    /// details.
+    MemInfo(MemInfo),
+    /// A variable-length bitmask array of all subscribed groups, capable of
+    /// exceeding the 32-group limit. This attribute is known as
+    /// `NETLINK_DIAG_GROUPS` in the kernel. See [Groups] for more details.
+    Groups(Groups),
+    /// Information about memory-mapped ring buffers for the socket. This
+    /// attribute is known as `NETLINK_DIAG_RX_RING` in the kernel. See
+    /// [RingInfo] for more details.
+    RxRing(RingInfo),
+    /// Information about memory-mapped ring buffers for the socket. This
+    /// attribute is known as `NETLINK_DIAG_TX_RING` in the kernel. See
+    /// [RingInfo] for more details.
+    TxRing(RingInfo),
+    /// Additional boolean flags about the socket's internal state. This
+    /// attribute is known as `NETLINK_DIAG_FLAGS` in the kernel. See
+    /// [StateFlags] for more details.
+    Flags(StateFlags),
+    /// Unknown attribute.
+    Other(DefaultNla),
+}
+
+pub const MEM_INFO_LEN: usize = 36;
+
+buffer!(MemInfoBuffer(MEM_INFO_LEN) {
+    rmem_alloc: (u32, 0..4),
+    rcvbuf: (u32, 4..8),
+    wmem_alloc: (u32, 8..12),
+    sndbuf: (u32, 12..16),
+    unused_fwd_alloc: (u32, 16..20),
+    unused_wmem_queued: (u32, 20..24),
+    sk_optmem: (u32, 24..28),
+    backlog: (u32, 28..32),
+    drops: (u32, 32..36),
+});
+
+/// Socket memory allocation and queue statistics.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct MemInfo {
+    /// The amount of memory (in bytes) currently allocated for receiving
+    /// packets.
+    pub rmem_alloc: u32,
+    /// The maximum allowed size (in bytes) of the receiving buffer
+    /// (`SO_RCVBUF`).
+    pub rcvbuf: u32,
+    /// The amount of memory (in bytes) currently allocated for sending
+    /// packets.
+    pub wmem_alloc: u32,
+    /// The maximum allowed size (in bytes) of the send buffer (`SO_SNDBUF`).
+    pub sndbuf: u32,
+    /// The amount of memory (in bytes) allocated for socket options and
+    /// control messages (ancillary data).
+    pub sk_optmem: u32,
+    /// The number of packets currently queued in the socket's backlog. These
+    /// are packets that have been received by the network stack but not
+    /// yet processed by the receiving application.
+    pub backlog: u32,
+    /// The total number of packets dropped by the socket. This typically
+    /// occurs when the receiving buffer (`rcvbuf`) is full.
+    pub drops: u32,
+}
+
+impl<T: AsRef<[u8]>> Parseable<MemInfoBuffer<T>> for MemInfo {
+    fn parse(buf: &MemInfoBuffer<T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            rmem_alloc: buf.rmem_alloc(),
+            rcvbuf: buf.rcvbuf(),
+            wmem_alloc: buf.wmem_alloc(),
+            sndbuf: buf.sndbuf(),
+            sk_optmem: buf.sk_optmem(),
+            backlog: buf.backlog(),
+            drops: buf.drops(),
+        })
+    }
+}
+
+impl Emitable for MemInfo {
+    fn buffer_len(&self) -> usize {
+        MEM_INFO_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = MemInfoBuffer::new(buf);
+
+        buf.set_rmem_alloc(self.rmem_alloc);
+        buf.set_rcvbuf(self.rcvbuf);
+        buf.set_wmem_alloc(self.wmem_alloc);
+        buf.set_sndbuf(self.sndbuf);
+        buf.set_unused_fwd_alloc(0);
+        buf.set_unused_wmem_queued(0);
+        buf.set_sk_optmem(self.sk_optmem);
+        buf.set_backlog(self.backlog);
+        buf.set_drops(self.drops);
+    }
+}
+
+/// The multicast groups the netlink socket is currently subscribed to.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct Groups(SmallVec<[u32; 8]>);
+
+impl Parseable<[u8]> for Groups {
+    fn parse(buf: &[u8]) -> Result<Self, DecodeError> {
+        if !buf.len().is_multiple_of(size_of::<u32>()) {
+            return Err("invalid groups length".into())
+        }
+
+        Ok(Self(
+            buf.chunks(size_of::<u32>())
+                .map(NativeEndian::read_u32)
+                .collect(),
+        ))
+    }
+}
+
+impl Groups {
+    /// Creates a new empty set of multicast groups.
+    pub fn new() -> Self {
+        Self(SmallVec::new())
+    }
+
+    fn index_and_offset(group: u32) -> (usize, u32) {
+        let bit_index = group - 1;
+        let vec_index = (bit_index / 32) as usize;
+        let bit_offset = bit_index % 32;
+        (vec_index, bit_offset)
+    }
+
+    fn group(vec_index: usize, bit_offset: u32) -> u32 {
+        (vec_index as u32 * 32) + bit_offset + 1
+    }
+
+    fn is_bit_set(bitmask: u32, bit_offset: u32) -> bool {
+        (bitmask & (1 << bit_offset)) != 0
+    }
+
+    /// Adds a multicast group.
+    pub fn add(&mut self, group: u32) {
+        // Group 0 is not valid.
+        if group == 0 {
+            return;
+        }
+
+        let (vec_index, bit_offset) = Self::index_and_offset(group);
+        if vec_index >= self.0.len() {
+            self.0.resize(vec_index + 1, 0)
+        }
+        self.0[vec_index] |= 1 << bit_offset;
+    }
+
+    /// Checks if the specified multicast group is present.
+    pub fn contains(&self, group: u32) -> bool {
+        // Group 0 is not valid.
+        if group == 0 {
+            return false;
+        }
+
+        let (vec_index, bit_offset) = Self::index_and_offset(group);
+
+        let Some(&bitmask) = self.0.get(vec_index) else {
+            return false;
+        };
+
+        Self::is_bit_set(bitmask, bit_offset)
+    }
+
+    /// Returns an iterator over all subscribed multicast groups.
+    pub fn iter(&self) -> impl Iterator<Item = u32> + '_ {
+        self.0.iter().enumerate().flat_map(|(vec_index, &bitmask)| {
+            (0..32).filter_map(move |bit_offset| {
+                if Self::is_bit_set(bitmask, bit_offset) {
+                    Some(Self::group(vec_index, bit_offset))
+                } else {
+                    None
+                }
+            })
+        })
+    }
+}
+
+impl FromIterator<u32> for Groups {
+    fn from_iter<T: IntoIterator<Item = u32>>(iter: T) -> Self {
+        let mut groups = Groups::new();
+        for group in iter {
+            groups.add(group)
+        }
+        groups
+    }
+}
+
+impl Emitable for Groups {
+    fn buffer_len(&self) -> usize {
+        self.0.len() * size_of::<u32>()
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut cursor = Cursor::new(buf);
+        for &v in self.0.iter() {
+            cursor.write_u32::<NativeEndian>(v).unwrap();
+        }
+    }
+}
+
+pub const NETLINK_DIAG_RING_LEN: usize = 16;
+
+buffer!(RingInfoBuffer(NETLINK_DIAG_RING_LEN) {
+    block_size: (u32, 0..4),
+    block_nr: (u32, 4..8),
+    frame_size: (u32, 8..12),
+    frame_nr: (u32, 12..16),
+});
+
+/// Configuration details for a memory-mapped netlink ring buffer.
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct RingInfo {
+    /// The size (in bytes) of a single contiguous memory block in the ring.
+    pub block_size: u32,
+    /// The total number of memory blocks allocated for the ring.
+    pub block_nr: u32,
+    /// The maximum size (in bytes) of a single Netlink frame (message) within
+    /// a block.
+    pub frame_size: u32,
+    /// The total number of frames across all blocks in the entire ring.
+    pub frame_nr: u32,
+}
+
+impl<T: AsRef<[u8]>> Parseable<RingInfoBuffer<T>> for RingInfo {
+    fn parse(buf: &RingInfoBuffer<T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            block_size: buf.block_size(),
+            block_nr: buf.block_nr(),
+            frame_size: buf.frame_size(),
+            frame_nr: buf.frame_nr(),
+        })
+    }
+}
+
+impl Emitable for RingInfo {
+    fn buffer_len(&self) -> usize {
+        NETLINK_DIAG_RING_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = RingInfoBuffer::new(buf);
+
+        buf.set_block_size(self.block_size);
+        buf.set_block_nr(self.block_nr);
+        buf.set_frame_size(self.frame_size);
+        buf.set_frame_nr(self.frame_nr);
+    }
+}
+bitflags! {
+    /// Internal state flags and socket options for a netlink socket.
+    pub struct StateFlags: u32 {
+        const CB_RUNNING = NDIAG_FLAG_CB_RUNNING;
+        const PKTINFO = NDIAG_FLAG_PKTINFO;
+        const BROADCAST_ERROR = NDIAG_FLAG_BROADCAST_ERROR;
+        const NO_ENOBUFS = NDIAG_FLAG_NO_ENOBUFS;
+        const LISTEN_ALL_NSID = NDIAG_FLAG_LISTEN_ALL_NSID;
+        const CAP_ACK = NDIAG_FLAG_CAP_ACK;
+    }
+}
+
+impl nla::Nla for Nla {
+    fn value_len(&self) -> usize {
+        use self::Nla::*;
+        match *self {
+            MemInfo(_) => MEM_INFO_LEN,
+            Groups(ref groups) => groups.buffer_len(),
+            RxRing(_) => NETLINK_DIAG_RING_LEN,
+            TxRing(_) => NETLINK_DIAG_RING_LEN,
+            Flags(_) => 4,
+            Other(ref attr) => attr.value_len(),
+        }
+    }
+
+    fn kind(&self) -> u16 {
+        use self::Nla::*;
+        match *self {
+            MemInfo(_) => NETLINK_DIAG_MEMINFO,
+            Groups(_) => NETLINK_DIAG_GROUPS,
+            RxRing(_) => NETLINK_DIAG_RX_RING,
+            TxRing(_) => NETLINK_DIAG_TX_RING,
+            Flags(_) => NETLINK_DIAG_FLAGS,
+            Other(ref attr) => attr.kind(),
+        }
+    }
+
+    fn emit_value(&self, buffer: &mut [u8]) {
+        use self::Nla::*;
+        match *self {
+            MemInfo(ref value) => value.emit(buffer),
+            Groups(ref value) => value.emit(buffer),
+            RxRing(ref value) => value.emit(buffer),
+            TxRing(ref value) => value.emit(buffer),
+            Flags(flags) => NativeEndian::write_u32(buffer, flags.bits()),
+            Other(ref attr) => attr.emit_value(buffer),
+        }
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NlaBuffer<&'a T>> for Nla {
+    fn parse(buf: &NlaBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let payload = buf.value();
+        Ok(match buf.kind() {
+            NETLINK_DIAG_MEMINFO => {
+                let err = "invalid NETLINK_DIAG_MEMINFO value";
+                let buf = MemInfoBuffer::new_checked(payload).context(err)?;
+                Self::MemInfo(MemInfo::parse(&buf).context(err)?)
+            }
+            NETLINK_DIAG_GROUPS => {
+                let err = "invalid NETLINK_DIAG_GROUPS value";
+                Self::Groups(Groups::parse(&payload).context(err)?)
+            }
+            NETLINK_DIAG_RX_RING => {
+                let err = "invalid NETLINK_DIAG_RX_RING value";
+                let buf = RingInfoBuffer::new_checked(payload).context(err)?;
+                Self::RxRing(RingInfo::parse(&buf).context(err)?)
+            }
+            NETLINK_DIAG_TX_RING => {
+                let err = "invalid NETLINK_DIAG_TX_RING value";
+                let buf = RingInfoBuffer::new_checked(payload).context(err)?;
+                Self::TxRing(RingInfo::parse(&buf).context(err)?)
+            }
+            NETLINK_DIAG_FLAGS => {
+                let err = "invalid NETLINK_DIAG_FLAGS value";
+                let payload_bytes = payload.get(..4).context(err)?;
+                let value = NativeEndian::read_u32(payload_bytes);
+                Self::Flags(StateFlags::from_bits_truncate(value))
+            }
+            kind => Self::Other(
+                DefaultNla::parse(buf)
+                    .context(format!("unknown NLA type {kind}"))?,
+            ),
+        })
+    }
+}

--- a/src/netlink/request.rs
+++ b/src/netlink/request.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+
+use std::convert::TryFrom;
+
+use netlink_packet_utils::{
+    buffer,
+    traits::{Emitable, Parseable},
+    DecodeError,
+};
+
+use crate::constants::*;
+
+pub const NETLINK_REQUEST_LEN: usize = 20;
+
+buffer!(NetlinkRequestBuffer(NETLINK_REQUEST_LEN) {
+    // The address family; it should be set to `AF_NETLINK`.
+    family: (u8, 0),
+    // The specific `NETLINK_*` netlink protocol to query or `NDIAG_PROTO_ALL`.
+    protocol: (u8, 1),
+    // This field should be set to `0`.
+    pad: (u16, 2..4),
+    // This is an inode number when querying for an individual socket. Ignored
+    // when querying for a list of sockets.
+    inode: (u32, 4..8),
+    // This is a set of flags defining what kind of information to report.
+    // Supported values are the `NDIAG_SHOW_*` constants.
+    show_flags: (u32, 8..12),
+    // This is an array of opaque identifiers that could be used along with
+    // ndiag_ino to specify an individual socket. It is ignored when querying
+    // for a list of sockets, as well as when all its elements are set to
+    // `0xff`.
+    cookie: (slice, 12..NETLINK_REQUEST_LEN),
+});
+
+/// The request for netlink domain sockets.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct NetlinkRequest {
+    /// The specific `NETLINK_*` netlink protocol to query.
+    ///
+    /// Use `NDIAG_PROTO_ALL` to query for all netlink protocols.
+    pub protocol: u8,
+    /// This is an inode number when querying for an individual socket.
+    ///
+    /// Ignored when querying for a list of sockets.
+    pub inode: u32,
+    /// This is a set of flags defining what kind of information to report.
+    ///
+    /// Each requested kind of information is reported back as a netlink
+    /// attribute.
+    pub show_flags: ShowFlags,
+    /// This is an opaque identifier that could be used to specify an
+    /// individual socket.
+    pub cookie: [u8; 8],
+}
+
+bitflags! {
+    /// Bitmask that defines what kind of information to report. Supported
+    /// values are the `NDIAG_SHOW_*` constants.
+    pub struct ShowFlags: u32 {
+        const MEMINFO = NDIAG_SHOW_MEMINFO;
+        const GROUPS = NDIAG_SHOW_GROUPS;
+        const RING_CFG = NDIAG_SHOW_RING_CFG;
+        const FLAGS = NDIAG_SHOW_FLAGS;
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + 'a> Parseable<NetlinkRequestBuffer<&'a T>>
+    for NetlinkRequest
+{
+    fn parse(buf: &NetlinkRequestBuffer<&'a T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            protocol: buf.protocol(),
+            inode: buf.inode(),
+            show_flags: ShowFlags::from_bits_truncate(buf.show_flags()),
+            // Unwrapping is safe because NetlinkRequestBuffer::cookie()
+            // returns a slice of exactly 8 bytes.
+            cookie: TryFrom::try_from(buf.cookie()).unwrap(),
+        })
+    }
+}
+
+impl Emitable for NetlinkRequest {
+    fn buffer_len(&self) -> usize {
+        NETLINK_REQUEST_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buffer = NetlinkRequestBuffer::new(buf);
+        buffer.set_family(AF_NETLINK);
+        buffer.set_protocol(self.protocol);
+        buffer.set_inode(self.inode);
+        buffer.set_pad(0);
+        buffer.set_show_flags(self.show_flags.bits());
+        buffer.cookie_mut().copy_from_slice(&self.cookie[..]);
+    }
+}

--- a/src/netlink/response.rs
+++ b/src/netlink/response.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: MIT
+
+use std::convert::TryFrom;
+
+use anyhow::Context;
+use netlink_packet_utils::{
+    buffer,
+    nla::{NlaBuffer, NlasIterator},
+    traits::{Emitable, Parseable},
+    DecodeError,
+};
+use smallvec::SmallVec;
+
+use crate::netlink::nlas::{Groups, RingInfo, StateFlags};
+use crate::{
+    constants::*,
+    netlink::nlas::{MemInfo, Nla},
+};
+
+pub const NETLINK_RESPONSE_HEADER_LEN: usize = 28;
+
+buffer!(NetlinkResponseBuffer(NETLINK_RESPONSE_HEADER_LEN) {
+    family: (u8, 0),
+    kind: (u8, 1),
+    protocol: (u8, 2),
+    state: (u8, 3),
+    portid: (u32, 4..8),
+    dst_portid: (u32, 8..12),
+    dst_group: (u32, 12..16),
+    inode: (u32, 16..20),
+    cookie: (slice, 20..NETLINK_RESPONSE_HEADER_LEN),
+    payload: (slice, NETLINK_RESPONSE_HEADER_LEN..),
+});
+
+/// The response to a query for netlink sockets.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct NetlinkResponseHeader {
+    /// One of `SOCK_RAW` or `SOCK_DGRAM`.
+    pub kind: u8,
+    /// One of `NETLINK_*` available netlink protocols, as documented in `man 7
+    /// netlink`.
+    pub protocol: u8,
+    /// State of the socket. It can be `NETLINK_UNCONNECTED` or
+    /// `NETLINK_CONNECTED`.
+    pub state: u8,
+    /// The local address of the netlink socket. This is 0 for a kernel socket,
+    /// and typically the process ID (or a generated unique identifier) for
+    /// userspace sockets.
+    pub portid: u32,
+    /// The remote address the netlink socket is connected to. This is 0 if the
+    /// socket is not connected or connected to the kernel.
+    pub dst_portid: u32,
+    /// A bitmask representing the first 32 multicast groups the socket is
+    /// currently subscribed to. Each set bit corresponds to a specific
+    /// multicast group within the netlink protocol. If the socket is not
+    /// listening to any multicast groups, this is 0. Any multicast group the
+    /// socket is subscribed to beyond the first 32 is accessible via the
+    /// `NETLINK_DIAG_GROUPS` attribute.
+    pub dst_group: u32,
+    /// Socket inode number.
+    pub inode: u32,
+    /// An opaque identifier that can be used along with the `inode` to
+    /// uniquely identify this specific socket instance.
+    pub cookie: [u8; 8],
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NetlinkResponseBuffer<&'a T>>
+    for NetlinkResponseHeader
+{
+    fn parse(buf: &NetlinkResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        Ok(Self {
+            kind: buf.kind(),
+            protocol: buf.protocol(),
+            state: buf.state(),
+            portid: buf.portid(),
+            dst_portid: buf.dst_portid(),
+            dst_group: buf.dst_group(),
+            inode: buf.inode(),
+            // Unwrapping is safe because NetlinkResponseBuffer::cookie()
+            // returns a slice of exactly 8 bytes.
+            cookie: TryFrom::try_from(buf.cookie()).unwrap(),
+        })
+    }
+}
+
+impl Emitable for NetlinkResponseHeader {
+    fn buffer_len(&self) -> usize {
+        NETLINK_RESPONSE_HEADER_LEN
+    }
+
+    fn emit(&self, buf: &mut [u8]) {
+        let mut buf = NetlinkResponseBuffer::new(buf);
+        buf.set_family(AF_NETLINK);
+        buf.set_kind(self.kind);
+        buf.set_protocol(self.protocol);
+        buf.set_state(self.state);
+        buf.set_portid(self.portid);
+        buf.set_dst_portid(self.dst_portid);
+        buf.set_dst_group(self.dst_group);
+        buf.set_inode(self.inode);
+        buf.cookie_mut().copy_from_slice(&self.cookie[..]);
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct NetlinkResponse {
+    pub header: NetlinkResponseHeader,
+    pub nlas: SmallVec<[Nla; 8]>,
+}
+
+impl NetlinkResponse {
+    pub fn mem_info(&self) -> Option<&MemInfo> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::MemInfo(mem_info) = nla {
+                Some(mem_info)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn groups(&self) -> Option<&Groups> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::Groups(groups) = nla {
+                Some(groups)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn rx_ring(&self) -> Option<&RingInfo> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::RxRing(ring_info) = nla {
+                Some(ring_info)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn tx_ring(&self) -> Option<&RingInfo> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::TxRing(ring_info) = nla {
+                Some(ring_info)
+            } else {
+                None
+            }
+        })
+    }
+
+    pub fn state_flags(&self) -> Option<StateFlags> {
+        self.nlas.iter().find_map(|nla| {
+            if let Nla::Flags(state_flags) = nla {
+                Some(*state_flags)
+            } else {
+                None
+            }
+        })
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> NetlinkResponseBuffer<&'a T> {
+    pub fn nlas(
+        &self,
+    ) -> impl Iterator<Item = Result<NlaBuffer<&'a [u8]>, DecodeError>> {
+        NlasIterator::new(self.payload())
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NetlinkResponseBuffer<&'a T>>
+    for SmallVec<[Nla; 8]>
+{
+    fn parse(buf: &NetlinkResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let mut nlas = smallvec![];
+        for nla_buf in buf.nlas() {
+            nlas.push(Nla::parse(&nla_buf?)?);
+        }
+        Ok(nlas)
+    }
+}
+
+impl<'a, T: AsRef<[u8]> + ?Sized> Parseable<NetlinkResponseBuffer<&'a T>>
+    for NetlinkResponse
+{
+    fn parse(buf: &NetlinkResponseBuffer<&'a T>) -> Result<Self, DecodeError> {
+        let header = NetlinkResponseHeader::parse(buf)
+            .context("failed to parse netlink response header")?;
+        let nlas = SmallVec::<[Nla; 8]>::parse(buf)
+            .context("failed to parse netlink response NLAs")?;
+        Ok(NetlinkResponse { header, nlas })
+    }
+}
+
+impl Emitable for NetlinkResponse {
+    fn buffer_len(&self) -> usize {
+        self.header.buffer_len() + self.nlas.as_slice().buffer_len()
+    }
+
+    fn emit(&self, buffer: &mut [u8]) {
+        self.header.emit(buffer);
+        self.nlas
+            .as_slice()
+            .emit(&mut buffer[self.header.buffer_len()..]);
+    }
+}

--- a/src/netlink/tests.rs
+++ b/src/netlink/tests.rs
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+
+use crate::netlink::nlas::{MemInfo, RingInfo, StateFlags};
+use crate::netlink::NetlinkResponseBuffer;
+use crate::{
+    constants::*,
+    netlink::{
+        nlas::Nla, NetlinkRequest, NetlinkResponse, NetlinkResponseHeader,
+        ShowFlags,
+    },
+};
+use netlink_packet_utils::traits::Emitable;
+use netlink_packet_utils::Parseable;
+
+lazy_static! {
+    static ref SOCKET_INFO: NetlinkRequest = NetlinkRequest {
+        protocol: NETLINK_ROUTE,
+        inode: 0x1234,
+        show_flags: ShowFlags::MEMINFO,
+        cookie: [0xff; 8]
+    };
+}
+
+#[rustfmt::skip]
+static SOCKET_INFO_BUF: [u8; 20] = [
+    0x10, // family: AF_NETLINK
+    0x00, // protocol: NETLINK_ROUTE
+    0x00, 0x00, // padding
+    0x34, 0x12, 0x00, 0x00, // inode number
+    0x01, 0x00, 0x00, 0x00, // show_flags - NDIAG_SHOW_MEMINFO
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, // cookie
+];
+
+#[test]
+fn emit_socket_info() {
+    assert_eq!(SOCKET_INFO.buffer_len(), 20);
+    let mut buf = vec![0xff; SOCKET_INFO.buffer_len()];
+    SOCKET_INFO.emit(&mut buf);
+    assert_eq!(&buf[..], &SOCKET_INFO_BUF[..]);
+}
+
+lazy_static! {
+    static ref LISTENING: NetlinkResponse = NetlinkResponse {
+        header: NetlinkResponseHeader {
+            kind: SOCK_DGRAM,
+            protocol: NETLINK_ROUTE,
+            state: NETLINK_UNCONNECTED,
+            portid: 0x5678,
+            dst_portid: 0,
+            dst_group: RTMGRP_LINK | RTMGRP_NEIGH,
+            inode: 20238,
+            cookie: [0xa0, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        },
+        nlas: smallvec![
+            // Use `IntoIterator::into_iter()` to explicitly iterate the array by value (see:
+            // https://doc.rust-lang.org/std/primitive.array.html#editions). This could be replaced
+            // with a call to `[...].into_iter()` once the crate is updated to edition 2021.
+            Nla::Groups(IntoIterator::into_iter([RTNLGRP_LINK, RTNLGRP_NEIGH]).collect()),
+            Nla::Flags(StateFlags::PKTINFO),
+            Nla::RxRing(RingInfo {
+                block_size: 16 * 1024,
+                block_nr: 4,
+                frame_size: 8 * 1024,
+                frame_nr: 8
+            }),
+        ]
+    };
+}
+
+#[rustfmt::skip]
+static LISTENING_BUF: [u8; 64] = [
+    0x10, // family: AF_NETLINK
+    0x02, // kind: SOCK_DGRAM
+    0x00, // protocol: NETLINK_ROUTE
+    0x00, // state: NETLINK_UNCONNECTED
+    0x78, 0x56, 0x00, 0x00, // portid
+    0x00, 0x00, 0x00, 0x00, // dst_portid
+    0x05, 0x00, 0x00, 0x00, // dst_group: RTMGRP_LINK | RTMGRP_NEIGH
+    0x0e, 0x4f, 0x00, 0x00, // inode number
+    0xa0, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // cookie
+
+    // NLAs
+   // 1. Groups
+    0x08, 0x00, // length: 8
+    0x01, 0x00, // type: NETLINK_DIAG_GROUPS
+    0x05, 0x00, 0x00, 0x00, // value: RTNLGRP_LINK | RTNLGRP_NEIGH
+
+    // 2. Flags
+    0x08, 0x00, // length: 8
+    0x04, 0x00, // type: NETLINK_DIAG_FLAGS
+    0x02, 0x00, 0x00, 0x00, // value: NDIAG_FLAG_PKTINFO
+
+    // 3. RxRing
+    0x14, 0x00, // length: 20
+    0x02, 0x00, // type: NETLINK_DIAG_RX_RING
+    0x00, 0x40, 0x00, 0x00, // block_size
+    0x04, 0x00, 0x00, 0x00, // block_nr
+    0x00, 0x20, 0x00, 0x00, // frame_size
+    0x08, 0x00, 0x00, 0x00, // frame_nr
+];
+
+#[test]
+fn parse_listening() {
+    let parsed = NetlinkResponse::parse(
+        &NetlinkResponseBuffer::new_checked(&&LISTENING_BUF[..]).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(parsed, *LISTENING);
+}
+
+#[test]
+fn emit_listening() {
+    assert_eq!(LISTENING.buffer_len(), 64);
+    // Initialize the buffer with 0xaa to check that padding bytes are set to 0.
+    let mut buf = vec![0xaa; LISTENING.buffer_len()];
+    LISTENING.emit(&mut buf);
+    assert_eq!(&buf[..], &LISTENING_BUF[..]);
+}
+
+lazy_static! {
+    static ref ESTABLISHED: NetlinkResponse = NetlinkResponse {
+        header: NetlinkResponseHeader {
+            kind: SOCK_RAW,
+            protocol: NETLINK_ROUTE,
+            state: NETLINK_CONNECTED,
+            portid: 0x1234,
+            dst_portid: 0,
+            dst_group: 0,
+            inode: 54321,
+            cookie: [0xbb, 0xcc, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+        },
+        nlas: smallvec![
+            Nla::MemInfo(MemInfo {
+                rmem_alloc: 1024,
+                rcvbuf: 8192,
+                wmem_alloc: 2048,
+                sndbuf: 16384,
+                sk_optmem: 0,
+                backlog: 5,
+                drops: 1,
+            }),
+            Nla::TxRing(RingInfo {
+                block_size: 4096,
+                block_nr: 2,
+                frame_size: 2048,
+                frame_nr: 4
+            }),
+        ]
+    };
+}
+
+#[rustfmt::skip]
+static ESTABLISHED_BUF: [u8; 88] = [
+    0x10, // family: AF_NETLINK
+    0x03, // kind: SOCK_RAW
+    0x00, // protocol: NETLINK_ROUTE
+    0x01, // state: NETLINK_CONNECTED
+    0x34, 0x12, 0x00, 0x00, // portid
+    0x00, 0x00, 0x00, 0x00, // dst_portid
+    0x00, 0x00, 0x00, 0x00, // dst_group
+    0x31, 0xd4, 0x00, 0x00, // inode number
+    0xbb, 0xcc, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // cookie
+
+    // NLAs
+    // 1. MemInfo
+    0x28, 0x00, // length: 40
+    0x00, 0x00, // type: NETLINK_DIAG_MEMINFO
+    0x00, 0x04, 0x00, 0x00, // rmem_alloc
+    0x00, 0x20, 0x00, 0x00, // rcvbuf
+    0x00, 0x08, 0x00, 0x00, // wmem_alloc
+    0x00, 0x40, 0x00, 0x00, // sndbuf
+    0x00, 0x00, 0x00, 0x00, // unused_fwd_alloc
+    0x00, 0x00, 0x00, 0x00, // unused_wmem_queued
+    0x00, 0x00, 0x00, 0x00, // sk_optmem
+    0x05, 0x00, 0x00, 0x00, // backlog
+    0x01, 0x00, 0x00, 0x00, // drops
+
+    // 2. TxRing
+    0x14, 0x00, // length: 20
+    0x03, 0x00, // type: NETLINK_DIAG_TX_RING
+    0x00, 0x10, 0x00, 0x00, // block_size
+    0x02, 0x00, 0x00, 0x00, // block_nr
+    0x00, 0x08, 0x00, 0x00, // frame_size
+    0x04, 0x00, 0x00, 0x00, // frame_nr
+];
+
+#[test]
+fn parse_established() {
+    let parsed = NetlinkResponse::parse(
+        &NetlinkResponseBuffer::new_checked(&&ESTABLISHED_BUF[..]).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(parsed, *ESTABLISHED);
+}
+
+#[test]
+fn emit_established() {
+    assert_eq!(ESTABLISHED.buffer_len(), 88);
+    // Initialize the buffer with 0xbb to check that padding bytes are set to 0.
+    let mut buf = vec![0xbb; ESTABLISHED.buffer_len()];
+    ESTABLISHED.emit(&mut buf);
+    assert_eq!(&buf[..], &ESTABLISHED_BUF[..]);
+}

--- a/src/unix/response.rs
+++ b/src/unix/response.rs
@@ -28,7 +28,7 @@ buffer!(UnixResponseBuffer(UNIX_RESPONSE_HEADER_LEN) {
     payload: (slice, UNIX_RESPONSE_HEADER_LEN..),
 });
 
-/// The response to a query for IPv4 or IPv6 sockets
+/// The response to a query for unix sockets.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct UnixResponseHeader {
     /// One of `SOCK_PACKET`, `SOCK_STREAM`, or `SOCK_SEQPACKET`


### PR DESCRIPTION
Hey! I was trying to build something to gather information regarding sockets from different network namespaces, and after implementing a solution to fetch info for `AF_INET`, `AF_INET6` and `AF_UNIX` sockets, I recognized there's no `AF_NETLINK` socket support here.

I tried my best to add the support here, but please notice that I'm not a diag sockets expert, and while I have dug into the kernel code to get some information about requests and responses layout, as well as NLAs, I could have missed/misunderstood something. Moreover, please notice that I copied the structure of the other `inet` and `unix` modules to write the `netlink` one.

I have a concern regarding the fact that I'm not sure I took the right choices while adding constants in `src/constants.rs`. First of all, I see that in some cases we use the ones provided by libc, and since there's already a dependency in place, I leveraged the same approach (not sure this is the best approach though). In some cases, libc doesn't expose all the required constants, so I hard-coded some of them. Finally, some of these constants are also exposed by other crates, like `rust-netlink/rtnetlink`, but I don't know if your policy is to use them or duplicating them here.

Please feel free to ask anything regarding the implementation and give me some advice regarding my doubt for constants.